### PR TITLE
Fix name of timestamp in log element

### DIFF
--- a/lib/ios-log.js
+++ b/lib/ios-log.js
@@ -77,8 +77,9 @@ class IOSLog {
         return;
       }
       let systemLogPath = path.resolve(logPath, 'system.log');
+      logger.debug(`System log path: ${systemLogPath}`);
       await mkdirp(logPath);
-      await fs.writeFile(systemLogPath, 'A new simulator is about to start!\n', {flag: 'a'});
+      await fs.writeFile(systemLogPath, 'A new Appium session is about to start!\n', {flag: 'a'});
       let files;
       try {
         files = await glob(systemLogPath);
@@ -166,7 +167,7 @@ class IOSLog {
         }
         if (this.loggingModeOn) {
           let logObj = {
-            timeStamp: Date.now(),
+            timestamp: Date.now(),
             level: 'ALL',
             message: log
           };


### PR DESCRIPTION
We have expected `timestamp` but it became `timeStamp` somewhere along the lines.