### PR TITLE
Fix to use udid option with idevicesyslog

### DIFF
--- a/lib/ios-log.js
+++ b/lib/ios-log.js
@@ -39,7 +39,7 @@ class IOSLog {
     logger.debug('Attempting iOS device log capture via libimobiledevice idevicesyslog');
     try {
       await which('idevicesyslog');
-      this.proc = new SubProcess('idevicesyslog', [], {env: spawnEnv});
+      this.proc = new SubProcess('idevicesyslog', ['-u', this.udid], {env: spawnEnv});
     } catch (err) {
       logger.warn('Could not capture device log using libimobiledevice idevicesyslog. ' +
                   'Libimobiledevice is probably not installed');


### PR DESCRIPTION
Without -u option idevicesyslog shows logs from any connected iOS device.