### PR TITLE
Make sure we don't fail if HOME environment variable is not set

### DIFF
--- a/lib/ios-crash-log.js
+++ b/lib/ios-crash-log.js
@@ -5,7 +5,7 @@ import logger from './logger';
 import { asyncmap } from 'asyncbox';
 
 
-const CRASH_DIR = path.resolve(process.env.HOME, 'Library', 'Logs', 'DiagnosticReports');
+const CRASH_DIR = path.resolve(process.env.HOME || '/', 'Library', 'Logs', 'DiagnosticReports');
 
 class IOSCrashLog {
   constructor (logDir = CRASH_DIR) {


### PR DESCRIPTION
If (as on windows, apparently) you don't have `HOME` set, you cannot start Appium at all.