### PR TITLE
Remove trim so logs keep their formatting

### DIFF
--- a/lib/ios-log.js
+++ b/lib/ios-log.js
@@ -156,7 +156,6 @@ class IOSLog {
 
     let logs = this.logRow.split('\n');
     for (let log of logs) {
-      log = log.trim();
       if (log) {
         if (!this.loggingModeOn) {
           // figure out if this log row marks the beginning of our log capture or not


### PR DESCRIPTION
Splitting on newlines removes the newlines, so there is no need to trim in order to get rid of them. This way we retain the formatting of the original logs...

```
info iOSLog [IOS_SYSLOG_ROW] Sep 26 15:12:06 isaac SpringBoard[6220]: Installed apps did change.
info iOSLog [IOS_SYSLOG_ROW] 	Added: {(
info iOSLog [IOS_SYSLOG_ROW] 	)}
info iOSLog [IOS_SYSLOG_ROW] 	Removed: {(
info iOSLog [IOS_SYSLOG_ROW] 	)}
info iOSLog [IOS_SYSLOG_ROW] 	Modified: {(
info iOSLog [IOS_SYSLOG_ROW] 	    "com.apple.test.WebDriverAgentRunner-Runner"
info iOSLog [IOS_SYSLOG_ROW] 	)}
```

Instead of...

```
info iOSLog [IOS_SYSLOG_ROW] Sep 26 15:12:06 isaac SpringBoard[6220]: Installed apps did change.
info iOSLog [IOS_SYSLOG_ROW] Added: {(
info iOSLog [IOS_SYSLOG_ROW] )}
info iOSLog [IOS_SYSLOG_ROW] Removed: {(
info iOSLog [IOS_SYSLOG_ROW] )}
info iOSLog [IOS_SYSLOG_ROW] Modified: {(
info iOSLog [IOS_SYSLOG_ROW] "com.apple.test.WebDriverAgentRunner-Runner"
info iOSLog [IOS_SYSLOG_ROW] )}
```